### PR TITLE
fixed writing to slack

### DIFF
--- a/lib/isis/connections/slack.rb
+++ b/lib/isis/connections/slack.rb
@@ -144,6 +144,7 @@ class Isis::Connections::Slack < Isis::Connections::Base
   end
 
   def speak(room, message, type = 'text')
+    room = "##{room}"
     if type == 'md'
       speak_md(room, message)
     else


### PR DESCRIPTION
Fix for issue 8: https://github.com/silentgrowl/isis/issues/8
```
Slack.chat_postMessage(channel: room, text: message, username: @username, name: @name, icon_url: @icon)
```
The parameter ```rooom``` contains the room name ('general', 'random', ...). I fixed it by prefixing it with a '#' ('#general', '#random', ...).

Please check this works for you too before merging it back.