### PR TITLE
Requiring activesupport in order to prevent error 

### DIFF
--- a/bin/isis
+++ b/bin/isis
@@ -7,6 +7,7 @@ $LOAD_PATH.unshift lib_dir if File.exist?(File.join(lib_dir, 'isis.rb'))
 require 'bundler/setup'
 require 'isis'
 require 'isis/chatbot'
+require 'active_support'
 require 'active_support/core_ext'
 require 'open-uri'
 


### PR DESCRIPTION
Error:

```
bin/isis
...
ruby-2.2.2/gems/activesupport-4.2.4/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
```

Fixing the runtime error that happens for me in ruby 2.2.2 with suggested/accepted fix from 
https://github.com/rails/rails/issues/14664#issuecomment-40191673

I don't know whether this is the way it's supposed to be, but it works for me :)

I am aware that isis is currently on 2.1.1 but I upgraded to 2.2.2 locally because it is the latest supported version. 
